### PR TITLE
Update template to not render empty sections

### DIFF
--- a/_layouts/albertine.html
+++ b/_layouts/albertine.html
@@ -124,6 +124,7 @@ It is threatened by habitat loss.
     </div>
   </div>
 
+  {% if site.data.publications.any? %}
   <div class="container">
     <div class="row">
       <section class="col-md-9">
@@ -163,7 +164,9 @@ It is threatened by habitat loss.
       </section>
     </div>
   </div>
+  {% endif %}
 
+  {% if site.data.projects.any? %}
   <!-- ==================== -->
   <!-- PROJECTS -->
   <!-- ==================== -->
@@ -207,7 +210,9 @@ It is threatened by habitat loss.
       </div>
     {% endfor %}
   </section>
+  {% endif %}
 
+  {% if site.data.presentations.any? %}
   <!-- ==================== -->
   <!-- PRESENTATIONS -->
   <!-- ==================== -->
@@ -241,6 +246,7 @@ It is threatened by habitat loss.
       </div>
     {% endfor %}
   </section>
+  {% endif %}
 
   <!-- ==================== -->
   <!-- FOOTER -->


### PR DESCRIPTION
Currently if I clear out a data file (such as `projects.yml`) then the heading is still rendered. This way, the whole section is skipped if there isn't any data to show.
